### PR TITLE
Avoid error on signOut when using some frameworks

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -6,8 +6,8 @@
 
 	user.set(supabase.auth.user())
 
-	supabase.auth.onAuthStateChange((_, session) => {
-		user.set(session.user)
+	supabase.auth.onAuthStateChange((state, session) => {
+		user.set(state === 'SIGNED_IN' && session.user)
 	})
 </script>
 


### PR DESCRIPTION
This fix was needed for my project using Astro.

Also nullart2 says this fix is needed for SvelteKit.

See: https://github.com/supabase/supabase/discussions/3468#discussioncomment-2742352

I think including this "fix" in the Supabase Svelte Quickstart could save a bunch of people (beginners like me) from many hours of headache :)